### PR TITLE
Remove JanusGraph configuration

### DIFF
--- a/openshift/job-template.yaml
+++ b/openshift/job-template.yaml
@@ -52,10 +52,6 @@ objects:
                   value: "0"
                 - name: THOTH_RESULT_API_URL
                   value: http://result-api
-                - name: THOTH_JANUSGRAPH_HOST
-                  value: janusgraph
-                - name: THOTH_JANUSGRAPH_PORT
-                  value: '8182'
                 - name: THOTH_MIDDLETIER_NAMESPACE
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
As we will use external service, this gets automatically propagated in
deployment.