### PR TITLE
use postgresql hostname from thoth configmap

### DIFF
--- a/openshift/job-template.yaml
+++ b/openshift/job-template.yaml
@@ -73,7 +73,10 @@ objects:
                       key: storage-bucket-name
                       name: thoth
                 - name: KNOWLEDGE_GRAPH_HOST
-                  value: postgresql
+                  valueFrom:
+                    configMapKeyRef:
+                      key: postgresql-host
+                      name: thoth
                 - name: KNOWLEDGE_GRAPH_PORT
                   value: "5432"
                 - name: KNOWLEDGE_GRAPH_SSL_DISABLED


### PR DESCRIPTION
use postgresql hostname from thoth configmap
depends-on: https://github.com/thoth-station/thoth-ops/pull/97
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>